### PR TITLE
Fix playlist bug

### DIFF
--- a/src/components/Slider.svelte
+++ b/src/components/Slider.svelte
@@ -8,7 +8,7 @@
   let iValue = values.indexOf(value);
 
   function onInput(e) {
-    value = values.find((_, i) => i === e.detail.value[0]);
+    value = values.find((_, i) => i === parseInt(e.detail.value[0]));
   }
 
   function getThumb(iValue) {

--- a/src/yt-auto-hd-content-script-functions.js
+++ b/src/yt-auto-hd-content-script-functions.js
@@ -34,14 +34,12 @@ export async function prepareToChangeQuality() {
 
 async function changeQuality(qualityCustom) {
   const fpsCurrent = getFPS();
-  const qualitiesCurrent = getCurrentQualities();
+  const qualitiesAvailable = getCurrentQualities();
+  const qualitiesUser = await getUserQualities();
   const elQualities = getCurrentQualityElements();
-  let qualitiesUser = await getUserQualities();
-  if (getIsFewerQualityValues(qualitiesUser, initial.qualities)) {
-    qualitiesUser = initial.qualities;
-  }
+
   const fps = getFpsFromRange(qualitiesUser, fpsCurrent);
-  const i = getIQuality(qualitiesCurrent, qualityCustom || qualitiesUser[fps]);
+  const i = getIQuality(qualitiesAvailable, qualityCustom || qualitiesUser[fps]);
 
   const isQualityExists = i > -1;
   if (isQualityExists) {
@@ -49,7 +47,7 @@ async function changeQuality(qualityCustom) {
   } else if (getIsQualityLower(elQualities[0], qualitiesUser[fps])) {
     elQualities[0].click();
   } else {
-    const iClosestQuality = qualitiesCurrent.findIndex(
+    const iClosestQuality = qualitiesAvailable.findIndex(
       quality => quality <= qualitiesUser[fps]
     );
     const isClosestQualityFound = iClosestQuality > -1;
@@ -168,11 +166,8 @@ function getFpsFromRange(qualities, fpsToCheck) {
  * @returns {Promise<Object>}
  */
 export async function getUserQualities() {
-  let qualities = (await getStorage("local", "qualities")) ?? {};
-  if (getIsFewerQualityValues(qualities, initial.qualities)) {
-    qualities = { ...qualities, ...initial.qualities };
-  }
-  return qualities;
+  let userQualities = (await getStorage("local", "qualities")) ?? {};
+  return { ...initial.qualities, ...userQualities };
 }
 
 /**

--- a/src/yt-auto-hd-content-script-initialize.js
+++ b/src/yt-auto-hd-content-script-initialize.js
@@ -16,22 +16,22 @@ function doVideoAction() {
 
 async function saveLastClick({ target: element, isTrusted }) {
   //We use programatic clicks to change quality, but we need to save/respond only to user clicks.
-  if (isTrusted) {
-    const elQuality = (() => {
-      if (element.matches("span")) {
-        return element;
-      }
-      if (element.matches("div")) {
-        return element.querySelector("span");
-      }
-      return null;
-    })();
-    const quality = parseInt(elQuality?.textContent);
-    if (isNaN(quality)) {
-      return;
+  if (!isTrusted) return;
+
+  const elQuality = (() => {
+    if (element.matches("span")) {
+      return element;
     }
-    window.ythdLastQualityClicked = quality;
+    if (element.matches("div")) {
+      return element.querySelector("span");
+    }
+    return null;
+  })();
+  const quality = parseInt(elQuality?.textContent);
+  if (isNaN(quality)) {
+    return;
   }
+  window.ythdLastQualityClicked = quality;
 }
 
 function addTemporaryBodyListener() {

--- a/src/yt-auto-hd-content-script-initialize.js
+++ b/src/yt-auto-hd-content-script-initialize.js
@@ -14,21 +14,24 @@ function doVideoAction() {
   prepareToChangeQuality();
 }
 
-async function saveLastClick({ target: element }) {
-  const elQuality = (() => {
-    if (element.matches("span")) {
-      return element;
+async function saveLastClick({ target: element, isTrusted }) {
+  //We use programatic clicks to change quality, but we need to save/respond only to user clicks.
+  if (isTrusted) {
+    const elQuality = (() => {
+      if (element.matches("span")) {
+        return element;
+      }
+      if (element.matches("div")) {
+        return element.querySelector("span");
+      }
+      return null;
+    })();
+    const quality = parseInt(elQuality?.textContent);
+    if (isNaN(quality)) {
+      return;
     }
-    if (element.matches("div")) {
-      return element.querySelector("span");
-    }
-    return null;
-  })();
-  const quality = parseInt(elQuality?.textContent);
-  if (isNaN(quality)) {
-    return;
+    window.ythdLastQualityClicked = quality;
   }
-  window.ythdLastQualityClicked = quality;
 }
 
 function addTemporaryBodyListener() {


### PR DESCRIPTION
This PR fixes https://github.com/avi12/youtube-auto-hd/issues/11

1. The bug was from overriding the user-set quality incorrectly. If the user changes the quality by clicking on a different setting, you save that on the window object - this is only relevant in playlists when the window object survives between different video loads.  The problem was the extension also uses clicks to set the quality. Added check to differentiate between user input and programmatic clicks, and the override only triggers on user input, not the extension's own clicks.
2. I fixed a little parsing bug in your slider component.
3. Refactored the `changeQuality` function a bit, for (hopefully) more clarity and less redundancy.