### PR TITLE
Add 1080p Premium support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "youtube-auto-hd",
   "displayName": "YouTube Auto HD + FPS",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "Automatically set the video quality on YouTube according to its FPS!",
   "author": "avi12 <avi6106@gmail.com>",
   "homepage": "https://github.com/avi12/youtube-auto-hd",

--- a/src/contents/content-script-init-desktop.ts
+++ b/src/contents/content-script-init-desktop.ts
@@ -80,7 +80,6 @@ function addTemporaryBodyListenerOnDesktop(): void {
         return;
       }
 
-
       // We need to reset global variables, as well as prepare to change the quality of the new video
       window.ythdLastQualityClicked = null;
       await prepareToChangeQualityOnDesktop();
@@ -112,7 +111,8 @@ async function init(): Promise<void> {
   // the video's quality will be changed as soon as it loads
   new MutationObserver(async (_, observer) => {
     const elVideo = getVisibleElement<HTMLVideoElement>(SELECTORS.video);
-    if (!elVideo) {
+    const elLogo = getVisibleElement(SELECTORS.logo);
+    if (!elVideo || !elLogo) {
       return;
     }
 

--- a/src/cs-helpers/desktop/content-script-desktop.ts
+++ b/src/cs-helpers/desktop/content-script-desktop.ts
@@ -1,5 +1,6 @@
 import {
   OBSERVER_OPTIONS,
+  QUALITY_TO_NOT_SELECT,
   SELECTORS,
   getFpsFromRange,
   getIQuality,
@@ -51,17 +52,17 @@ function getCurrentQualityElements(): HTMLDivElement[] {
   return elMenuOptions.filter(getIsQualityElement) as HTMLDivElement[];
 }
 
-function convertQualityToNumber(elQuality: Element): VideoQuality | 0 {
+function convertQualityToNumber(elQuality: Element): VideoQuality | typeof QUALITY_TO_NOT_SELECT {
   const isPremiumAccount = Boolean(getVisibleElement(SELECTORS.logo).querySelector(SELECTORS.logoPremium));
   const isPremiumQuality = Boolean(elQuality.querySelector(SELECTORS.labelPremium));
   const qualityNumber = parseInt(elQuality.textContent) as VideoQuality;
   if (!isPremiumQuality) {
     return qualityNumber;
   }
-  return !isPremiumAccount ? 0 : qualityNumber;
+  return !isPremiumAccount ? QUALITY_TO_NOT_SELECT : qualityNumber;
 }
 
-function getCurrentQualities(): (VideoQuality | 0)[] {
+function getCurrentQualities(): (VideoQuality | typeof QUALITY_TO_NOT_SELECT)[] {
   const elQualities = getCurrentQualityElements();
   return elQualities.map(convertQualityToNumber);
 }
@@ -96,7 +97,7 @@ function changeQuality(qualityCustom?: VideoQuality): void {
   if (isQualityExists) {
     applyQuality(iQuality);
   } else if (getIsQualityLower(elQualities[0], window.ythdLastUserQualities[fpsStep])) {
-    const iQualityAvailable = qualitiesAvailable.findIndex(quality => quality > 0);
+    const iQualityAvailable = qualitiesAvailable.findIndex(quality => quality > QUALITY_TO_NOT_SELECT);
     applyQuality(iQualityAvailable);
   } else {
     const iClosestQuality = qualitiesAvailable.findIndex(quality => quality <= window.ythdLastUserQualities[fpsStep]);

--- a/src/cs-helpers/desktop/content-script-desktop.ts
+++ b/src/cs-helpers/desktop/content-script-desktop.ts
@@ -52,7 +52,7 @@ function getCurrentQualityElements(): HTMLDivElement[] {
 }
 
 function convertQualityToNumber(elQuality: Element): VideoQuality | 0 {
-  const isPremiumAccount = Boolean(getVisibleElement(SELECTORS.logoPremium));
+  const isPremiumAccount = Boolean(getVisibleElement(SELECTORS.logo).querySelector(SELECTORS.logoPremium));
   const isPremiumQuality = Boolean(elQuality.querySelector(SELECTORS.labelPremium));
   const qualityNumber = parseInt(elQuality.textContent) as VideoQuality;
   if (!isPremiumQuality) {

--- a/src/shared-scripts/ythd-utils.ts
+++ b/src/shared-scripts/ythd-utils.ts
@@ -9,6 +9,7 @@ import type { QualityFpsPreferences, VideoFPS, VideoQuality, YouTubeLabel } from
 const storageLocal = new Storage({ area: "local" });
 
 export const OBSERVER_OPTIONS: MutationObserverInit = Object.freeze({ childList: true, subtree: true });
+export const QUALITY_TO_NOT_SELECT = 0;
 window.ythdLastUserQualities = { ...initial.qualities };
 
 export async function getStorage<T>({

--- a/src/shared-scripts/ythd-utils.ts
+++ b/src/shared-scripts/ythd-utils.ts
@@ -65,6 +65,7 @@ export enum SELECTORS {
   actionButtonsContainer = "#top-row #owner",
   donationSection = ".ythd-donation-section",
   // Premium
+  logo = "ytd-logo",
   logoPremium = "#youtube-red-paths",
   labelPremium = ".ytp-premium-label",
   // Mobile


### PR DESCRIPTION
The extension now supports the higher bitrate by simply selecting it whenever possible
For example, suppose a YouTube account is eligible for this new quality and enterss such a video
If the user has selected in the ext preferences in 30FPS the quality "1440p", but the video's highest quality is 1080p Premium, then the 1080 Premium will be selected
If, on the other hand, the highest quality is 1440p - 1440p will be selected, since the given quality will be higher
Of course, if the user has selected 1080p and the video's highest quality is 1080p Premium, the 1080p Premium will be selected 

Closed #99